### PR TITLE
Resolves "Unable to register service worker" Issue

### DIFF
--- a/flask-pwa.py
+++ b/flask-pwa.py
@@ -15,7 +15,7 @@ def offline():
 
 @app.route('/service-worker.js')
 def sw():
-    return app.send_static_file('service-worker.js')
+    return app.send_static_file('service-worker.js'), 200, {'Content-Type': 'text/javascript'}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves the issue "Unable to register service worker... The script has an unsupported MIME type ('text/plain')." Also, I strongly suggest using https://www.pwabuilder.com/serviceworker to generate a service worker for your needs.